### PR TITLE
standardize and DRY out format of html titles

### DIFF
--- a/public/_templates/bootstrap/_translations/translations_en.ini
+++ b/public/_templates/bootstrap/_translations/translations_en.ini
@@ -11,6 +11,7 @@
 [header]
 name = "fossjobs.net"
 title = "FOSS jobs"
+title_sep = " | "
 home = "Home"
 rss_alt = "RSS"
 rss_title = "Subscribe to the RSS feed"

--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -27,6 +27,8 @@
 	}
 	
 	$job = new Job();
+
+	$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
 	
 	switch($page)
 	{
@@ -121,7 +123,7 @@
 				redirect_to(BASE_URL);
 				exit;
 			}
-			$html_title = 'Page unavailable / ' . SITE_NAME;
+			$html_title = 'Page unavailable' . $title_suffix;
 			$template = 'error.tpl';
 			$flag = 1;
 			break;
@@ -170,7 +172,7 @@
 				exit;
 			}
 			require_once 'page_password.php';
-			$html_title = 'Change password / ' . SITE_NAME;
+			$html_title = 'Change password' . $title_suffix;
 			$template = 'password.tpl';
 			$flag = 1;
 			break;

--- a/public/admin/page_edit_post.php
+++ b/public/admin/page_edit_post.php
@@ -141,8 +141,8 @@ if ($id != 0)
 	$smarty->assign('categories', get_categories());
 	$smarty->assign('types', get_types());
 	$smarty->assign('countries', get_countries());
-	
-	$html_title = $translations['jobs']['title_edit'] . ' / ' . SITE_NAME;
+	$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
+	$html_title = $translations['jobs']['title_edit'] . $title_suffix;
 	
 	$template = 'edit-post.tpl';
 ?>

--- a/public/admin/page_job.php
+++ b/public/admin/page_job.php
@@ -24,7 +24,8 @@
 		$category = get_category_by_id($info['category_id']);
 		$category_var_name = $category['var_name'];
 		
-		$html_title = stripslashes($info['title']) . ' la ' . stripslashes($info['company']) . ' / ' . SITE_NAME;
+		$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
+		$html_title = stripslashes($info['title']) . ' la ' . stripslashes($info['company']) . $title_suffix;
 		
 		if(isset($_SERVER['HTTP_REFERER']))
 		{

--- a/public/admin/page_pages.php
+++ b/public/admin/page_pages.php
@@ -124,14 +124,14 @@
 		}
 		$smarty->assign('defaults', $defaults);
 		$smarty->assign('errors', $errors);
-		$html_title = $isPage ? 'Editing page ' . $row['title'] . ' / ' : '';
-		$html_title .= SITE_NAME;
+		$html_title = $isPage ? 'Editing page ' . $row['title'] . $translations['header']['title_sep'] : '';
+		$html_title .= $translations['header']['name'];
 		$smarty->assign('editor', true);
 		$template = 'page_edit.tpl';
 		$js[] = 'editor';
 	} else {
 		$smarty->assign('list_pages', true);
-		$html_title = 'Pages / ' . SITE_NAME;
+		$html_title = 'Pages' . $translations['header']['title_sep'] . $translations['header']['name'];
 		$template = 'pages.tpl';
 	}
 		

--- a/public/index.php
+++ b/public/index.php
@@ -32,6 +32,8 @@
 	
 	$meta_description = '';
 	$meta_keywords = '';
+
+	$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
 	
 	if(!isset($_SERVER['HTTP_REFERER'])) 
 	{
@@ -148,18 +150,18 @@
 			
 		case 'rss':
 			require_once 'page_rss.php';
-			$html_title = 'RSS Feeds for ' . SITE_NAME;
+			$html_title = 'RSS Feeds' . $title_suffix;
 			$flag = 1;
 			break;
 			
 		case 'sitemap':
-			$html_title = 'Sitemap';
+			$html_title = 'Sitemap' . $title_suffix;
 			$template = 'sitemap.tpl';
 			$flag = 1;
 			break;
 			
 		case 'widgets':
-			$html_title = 'Widgets - ' . SITE_NAME;
+			$html_title = 'Widgets' . $title_suffix;
 			$template = 'widgets.tpl';
 			$flag = 1;
 			break;		
@@ -176,7 +178,7 @@
 			break;
 			
 		case 'job-unavailable':
-			$html_title = 'Unavailable job / ' . SITE_NAME;
+			$html_title = 'Unavailable job' . $title_suffix;
 			$template = 'no-job.tpl';
 			$flag = 1;
 			break;
@@ -194,7 +196,7 @@
 		// 404 etc. error page
 		case 'page-unavailable':
 			// TO-DO: add suggestion if no trailing slash supplied
-			$html_title = 'Page unavailable / ' . SITE_NAME;
+			$html_title = 'Page unavailable' . $title_suffix;
 			$template = 'error.tpl';
 			$flag = 1;
 			break;
@@ -211,7 +213,7 @@
 			$pageData = $result->fetch_assoc();
 			if (is_array($pageData)) {
 				require_once 'page_page.php';
-				$html_title = $pageData['page_title'] . ' - ' . SITE_NAME;
+				$html_title = $pageData['page_title'] . $title_suffix;
 				$meta_keywords = $pageData['keywords'];
 				$meta_description = $pageData['description'];
 				$template = 'page.tpl';

--- a/public/page_publish.php
+++ b/public/page_publish.php
@@ -15,12 +15,14 @@
 	
 	$postMan->MailPublishToAdmin($jobInfo);
 
+	$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
+
 	if ($postRequiresModeration)
 	{
 		if ($isNewPost)
 			$postMan->MailPublishPendingToUser($job->mPosterEmail);
 		
-		$html_title = $translations['jobs']['add_success'] . ' / ' . SITE_NAME;
+		$html_title = $translations['jobs']['add_success'] . $title_suffix;
 	}
 	else
 	{
@@ -30,7 +32,7 @@
 		if ($isNewPost)
 			$postMan->MailPublishToUser($jobInfo);
 		
-		$html_title = $translations['jobs']['publish_success'] . ' / ' . SITE_NAME;
+		$html_title = $translations['jobs']['publish_success'] . $title_suffix;
 	}
 	
 	$smarty->assign('postRequiresModeration', $postRequiresModeration);

--- a/public/page_verify.php
+++ b/public/page_verify.php
@@ -30,6 +30,7 @@
 		$jobInfo['description'] = str_replace(array("\r\n", "\r", "\n"), "<br />", $jobInfo['description']);
 	}
 	$smarty->assign('job', $jobInfo);
-	$html_title = stripslashes($jobInfo['title']) . ' at ' . stripslashes($jobInfo['company']) . ' / ' . SITE_NAME;
+	$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
+	$html_title = stripslashes($jobInfo['title']) . ' at ' . stripslashes($jobInfo['company']) . $title_suffix;
 	$template = 'publish-verify.tpl';
 ?>

--- a/public/page_write.php
+++ b/public/page_write.php
@@ -255,14 +255,16 @@
 	$smarty->assign('categories', get_categories());
 	$smarty->assign('types', get_types());
 	$smarty->assign('countries', get_countries());
+
+	$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
 	
 	if ($later_edit)
 	{
-		$html_title = $translations['jobs']['title_edit'] . ' / ' . SITE_NAME;
+		$html_title = $translations['jobs']['title_edit'] . $title_suffix;
 	}
 	else
 	{
-		$html_title = $translations['jobs']['title_new'] . ' / ' . SITE_NAME;
+		$html_title = $translations['jobs']['title_new'] . $title_suffix;
 	}
 	
 	if (isset($apply_online))


### PR DESCRIPTION
Some of the pages used `/` as a separator between the page-specific title and the site name, while a couple used `-`. This change introduces a new translation key that allows making sure the titles all use the same format, and changing it to something else (if so desired) in a more modular way.