### PR TITLE
Move job-type color marker into the job-type tag

### DIFF
--- a/public/_templates/bulma/company-posts-loop.tpl
+++ b/public/_templates/bulma/company-posts-loop.tpl
@@ -14,11 +14,11 @@
 								{$job.created_on} - {$translations.homepage.at}
 								{if $compjob.url && $compjob.url != 'http://'}
 									<a href="{$compjob.url}" class="neutral-link">{$compjob.company}</a>
-									{else}
+								{else}
 									{$compjob.company}
-									{/if}
+								{/if}
 
-								{if $compjob.is_location_anywhere}, {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$compjob.location}{/if}
+								{if $compjob.is_location_anywhere}— {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$compjob.location}{/if}
 
 								<a href="{$BASE_URL}jobs/{$compjob.type_var_name}/">
 									<div class="tag">

--- a/public/_templates/bulma/company-posts-loop.tpl
+++ b/public/_templates/bulma/company-posts-loop.tpl
@@ -8,11 +8,6 @@
 			<article class="post">
 				<h3><a href="{$BASE_URL}{$URL_JOB}/{$compjob.id}/{$compjob.url_title}/" title="{$compjob.title}">{$compjob.title}</a></h3>
 				<div class="media">
-					<div class="media-left">
-						<span class="bd-color {$job.type_var_name}" alt="{$job.type_name}"/>
-							&nbsp;
-						</span>
-					</div>
 					<div class="media-content">
 						<div class="content">
 							<p>
@@ -25,7 +20,12 @@
 
 								{if $compjob.is_location_anywhere}, {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$compjob.location}{/if}
 
-								<span class="tag {$compjob.type_name}">{$compjob.type_name}</span>
+								<a href="{$BASE_URL}jobs/{$compjob.type_var_name}/">
+									<div class="tag">
+										{$compjob.type_name}
+										<span class="bd-color {$compjob.type_var_name}">&nbsp;</span>
+									</div>
+								</a>
 							</p>
 						</div>
 					</div>

--- a/public/_templates/bulma/css/forum.css
+++ b/public/_templates/bulma/css/forum.css
@@ -58,11 +58,9 @@ article.post:last-child {
 }
 
 .bd-color {
-  border-radius:2px;
   border-radius: 50%;
   box-shadow:0 2px 3px 0 rgba(0,0,0,.1),inset 0 0 0 1px rgba(0,0,0,.1);
-  margin-top:7px;
-  float:left;
+  margin-left:0.5em;
   width:14px;
   height:14px;
  }

--- a/public/_templates/bulma/home.tpl
+++ b/public/_templates/bulma/home.tpl
@@ -35,7 +35,7 @@
 											{$job.company}
 										{/if}
 
-										{if $job.is_location_anywhere}, {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
+										{if $job.is_location_anywhere}— {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
 
 										<a href="{$BASE_URL}jobs/{$job.type_var_name}/">
 											<div class="tag">

--- a/public/_templates/bulma/home.tpl
+++ b/public/_templates/bulma/home.tpl
@@ -25,11 +25,6 @@
 					<article class="post">
 						<h3><a href="{$BASE_URL}{$URL_JOB}/{$job.id}/{$job.url_title}/">{$job.title}</a></h3>
 						<div class="media">
-							<div class="media-left">
-								<span class="bd-color {$job.type_var_name}">
-									&nbsp;
-								</span>
-							</div>
 							<div class="media-content">
 								<div class="content">
 									<p>
@@ -42,7 +37,12 @@
 
 										{if $job.is_location_anywhere}, {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
 
-										<a href="{$BASE_URL}jobs/{$job.type_var_name}/"><span class="tag {$job.type_name}">{$job.type_name}</span></a>
+										<a href="{$BASE_URL}jobs/{$job.type_var_name}/">
+											<div class="tag">
+												{$job.type_name}
+												<span class="bd-color {$job.type_var_name}">&nbsp;</span>
+											</div>
+										</a>
 									</p>
 								</div>
 							</div>

--- a/public/_templates/bulma/jobs-list.tpl
+++ b/public/_templates/bulma/jobs-list.tpl
@@ -13,7 +13,7 @@
 						{$job.company}
 					{/if}
 
-					{if $job.is_location_anywhere}, {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
+					{if $job.is_location_anywhere}— {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
 
 					<a href="{$BASE_URL}jobs/{$job.type_var_name}/">
 						<div class="tag">

--- a/public/_templates/bulma/jobs-list.tpl
+++ b/public/_templates/bulma/jobs-list.tpl
@@ -3,11 +3,6 @@
 <article class="post">
 	<h2><a href="{$BASE_URL}{$URL_JOB}/{$job.id}/{$job.url_title}/" title="{$job.title}">{$job.title}</a></h2>
 	<div class="media">
-		<div class="media-left">
-			<span class="bd-color {$job.type_var_name}">
-				&nbsp;
-			</span>
-		</div>
 		<div class="media-content">
 			<div class="content">
 				<p>
@@ -20,7 +15,12 @@
 
 					{if $job.is_location_anywhere}, {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
 
-					<a href="{$BASE_URL}jobs/{$job.type_var_name}/"><span class="tag {$job.type_name}">{$job.type_name}</span></a>
+					<a href="{$BASE_URL}jobs/{$job.type_var_name}/">
+						<div class="tag">
+							{$job.type_name}
+							<span class="bd-color {$job.type_var_name}">&nbsp;</span>
+						</div>
+					</a>
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
This way, it becomes evident what the color means. Before, there was no tooltip or other hint that would indicate what the colored bullets are supposed to mean, so their meaning could only be gleaned by guessing.

Besides, this also avoids representing the same information in two different places, which is definitely not a good UX.

As a bonus, this also simplifies the logic in the code!

Before:
![Screenshot 2021-04-18 at 20 20 27](https://user-images.githubusercontent.com/478237/115158428-f4051380-a085-11eb-8970-41425cec089f.png)

After:
![Screenshot 2021-04-18 at 20 20 03](https://user-images.githubusercontent.com/478237/115158426-f1a2b980-a085-11eb-817b-8625793f7b98.png)

----
Note: I've added a tangentially unrelated commit tweaking the punctuation for the "Worldwide/Remote" suffix of the job entries in these pages, since the previous one (a comma) didn't work well because it was preceded by a space in the rendered page.
