### PR TITLE
Ensure width and height apply to job type bubbles

### DIFF
--- a/public/_templates/bulma/css/forum.css
+++ b/public/_templates/bulma/css/forum.css
@@ -59,10 +59,11 @@ article.post:last-child {
 
 .bd-color {
   border-radius: 50%;
-  box-shadow:0 2px 3px 0 rgba(0,0,0,.1),inset 0 0 0 1px rgba(0,0,0,.1);
-  margin-left:0.5em;
-  width:14px;
-  height:14px;
+  box-shadow: 0 2px 3px 0 rgba(0,0,0,.1),inset 0 0 0 1px rgba(0,0,0,.1);
+  margin-left: 0.5em;
+  display: inline-block;
+  width: 14px;
+  height: 14px;
  }
 a.neutral-link {
   color: #000000;

--- a/public/_templates/bulma/css/forum.css
+++ b/public/_templates/bulma/css/forum.css
@@ -61,7 +61,7 @@ article.post:last-child {
   border-radius: 50%;
   box-shadow: 0 2px 3px 0 rgba(0,0,0,.1),inset 0 0 0 1px rgba(0,0,0,.1);
   margin-left: 0.5em;
-  display: inline-block;
+  display: inline-flex;
   width: 14px;
   height: 14px;
  }
@@ -93,6 +93,7 @@ a.neutral-link {
 }
 .tag {
   margin-left: 3px;
+  display: inline-flex;
 }
 .content h1,.content h2,.content h3 {
   font-size: 1.25em;


### PR DESCRIPTION
Follow-up of #41: add `display: inline-flex` to:
- the `span.bd-color` elements, to make sure the `width` and `height` properties are applied, thus ensuring the circular look rather than horizontally squished
- the `div.tag` elements, to prevent browsers from assuming `display: block`, which would make them break the horizontal layout of their container and be placed in a new row.

Both issues above are illustrated in the screenshot below, originally posted [here](https://github.com/fossjobs/fossjobs/pull/41#issuecomment-823632722):

![](https://user-images.githubusercontent.com/347406/115470072-0c1b9500-a236-11eb-8ff5-5685d310ddf6.png)

I am not sure why this is needed, since in my local tests, neither Firefox, nor Chrome, nor Safari required it to make the design work. But in any case, it is better to be explicit anyway, so this is a net positive regardless.