### PR TITLE
Fix display of job type markers

### DIFF
--- a/public/_templates/bulma/company-posts-loop.tpl
+++ b/public/_templates/bulma/company-posts-loop.tpl
@@ -21,10 +21,10 @@
 								{if $compjob.is_location_anywhere}— {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$compjob.location}{/if}
 
 								<a href="{$BASE_URL}jobs/{$compjob.type_var_name}/">
-									<div class="tag">
+									<span class="tag">
 										{$compjob.type_name}
 										<span class="bd-color {$compjob.type_var_name}">&nbsp;</span>
-									</div>
+									</span>
 								</a>
 							</p>
 						</div>

--- a/public/_templates/bulma/css/forum.css
+++ b/public/_templates/bulma/css/forum.css
@@ -61,7 +61,7 @@ article.post:last-child {
   border-radius: 50%;
   box-shadow: 0 2px 3px 0 rgba(0,0,0,.1),inset 0 0 0 1px rgba(0,0,0,.1);
   margin-left: 0.5em;
-  display: inline-flex;
+  display: inline-block;
   width: 14px;
   height: 14px;
  }
@@ -93,7 +93,6 @@ a.neutral-link {
 }
 .tag {
   margin-left: 3px;
-  display: inline-flex;
 }
 .content h1,.content h2,.content h3 {
   font-size: 1.25em;

--- a/public/_templates/bulma/home.tpl
+++ b/public/_templates/bulma/home.tpl
@@ -37,10 +37,10 @@
 										{if $job.is_location_anywhere}— {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
 
 										<a href="{$BASE_URL}jobs/{$job.type_var_name}/">
-											<div class="tag">
+											<span class="tag">
 												{$job.type_name}
 												<span class="bd-color {$job.type_var_name}">&nbsp;</span>
-											</div>
+											</span>
 										</a>
 									</p>
 								</div>

--- a/public/_templates/bulma/jobs-list.tpl
+++ b/public/_templates/bulma/jobs-list.tpl
@@ -16,10 +16,10 @@
 					{if $job.is_location_anywhere}— {$translations.jobs.location_anywhere}{else}{$translations.homepage.in} {$job.location}{/if}
 
 					<a href="{$BASE_URL}jobs/{$job.type_var_name}/">
-						<div class="tag">
+						<span class="tag">
 							{$job.type_name}
 							<span class="bd-color {$job.type_var_name}">&nbsp;</span>
-						</div>
+						</span>
 					</a>
 				</p>
 			</div>


### PR DESCRIPTION
These tags were being created as block elements (`<div>` elements), which are not permitted inside paragraphs (`<p>` elements).

This change makes them into `<span>` elements, which are valid there.
This avoids a browser-initiated reshuffling of the elements, which was breaking the layout of the job listings (by making the tags appear on the line under the job details).

(This is a follow-up of #41 and #42.)