### PR TITLE
Reduce size and tweak colors of job-type bullets

### DIFF
--- a/public/_templates/bulma/css/forum.css
+++ b/public/_templates/bulma/css/forum.css
@@ -62,8 +62,8 @@ article.post:last-child {
   box-shadow: 0 2px 3px 0 rgba(0,0,0,.1),inset 0 0 0 1px rgba(0,0,0,.1);
   margin-left: 0.5em;
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
  }
 a.neutral-link {
   color: #000000;
@@ -72,10 +72,10 @@ a.neutral-link {
   background-color: #e2df24;
 }
 .parttime {
-  background-color: #f89406;
+  background-color: #faad48;
 }
 .freelance {
-  background-color: #0072ff;
+  background-color: #c591ff;
 }
 .internship {
   background-color: #62cffc;


### PR DESCRIPTION
Now that the colored bullet is inside the tag itself, the diameter of the circle should be adjusted to harmonize better with the text alongside it.

Additionally, the colors have been tweaked to make them more distinguishable in hue (no longer there are two blues) and less divergent in terms of luminance.

Before: `#e2df24`, `#f89406`, `#0072ff`, `#62cffc`.
After: `#e2df24`, `#faad48`, `#c591ff`, `#62cffc`.

These colors have been validated with Adobe's [color accessibility checker](https://color.adobe.com/create/color-accessibility) to confirm they remain distinguishable for people with different types of color blindness:

| Before | After |
| ------ | ----- |
| ![Screenshot 2021-07-07 at 11 04 39](https://user-images.githubusercontent.com/478237/124742605-c9a05500-df14-11eb-9d08-572f00bdfd6f.png) | ![Screenshot 2021-07-07 at 11 14 00](https://user-images.githubusercontent.com/478237/124742606-ca38eb80-df14-11eb-9238-9d9e69f984f8.png) |
