### PR TITLE
fix overflow on mobile caused by select

### DIFF
--- a/public/_templates/bulma/publish-write.tpl
+++ b/public/_templates/bulma/publish-write.tpl
@@ -65,8 +65,8 @@
 						</div>
 					</div>
 
-					<div class="field is-grouped">
-						<div class="control">
+					<div class="field is-grouped is-grouped-multiline">
+						<div class="control" style="max-width: 100%;">
 							<label for="country_id" class="label is-sr-only">Country</label>
 							<div class="select">
 								<select name="country_id" id="country_id">


### PR DESCRIPTION
Hi,

while navigating the site on mobile, I realized an overflow on submit page cause by the (large) country select box.

Instead of manually setting `width` for country and city, we should use Bulmas `is-grouped-multiline` class, see https://github.com/jgthms/bulma/issues/322#issuecomment-432346566

In addition, I had to set a `max-width: 100%` inline for the country select box, because it's still too wide on small mobiles. I am unsure whether this is a bulma bug or not.

Cheers
midzer