### PR TITLE
Update social media links and contact info in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,19 @@
 It uses the open source software [Jobberbase](http://www.jobberbase.com/).
 See [their README.md](https://github.com/filipcte/jobberbase/blob/master/README.md) for links and installation guides.
 
-You can [post a job on the website](https://www.fossjobs.net/post/), as long as it directly improves FOSS or open hardware projects. You can also submit jobs directly by emailing submit@fossjobs.net.
+You can [post a job on the website](https://www.fossjobs.net/post/),
+as long as it directly improves FOSS or open hardware projects.
+You can also submit jobs directly by emailing <submit@fossjobs.net>.
 
-## Social networks
+In addition to the website, submitted jobs are also published in the following places:
 
-Connect with us on [Twitter](https://twitter.com/fossjobs_net) and [Facebook](https://www.facebook.com/fossjobs.net).
+- [RSS feeds](https://www.fossjobs.net/rss/)
+- [Mastodon](https://fosstodon.org/@fossjobs)
+- [Twitter](https://twitter.com/fossjobs_net)
+
+## Contact
+
+Connect with the community via [IRC](ircs://irc.libera.chat/#fossjobs)
+or through the [issue tracker](https://github.com/fossjobs/fossjobs/issues) on GitHub.
+
+You can also message/mention the Twitter or Mastodon accounts directly.

--- a/public/_templates/bulma/home.tpl
+++ b/public/_templates/bulma/home.tpl
@@ -12,7 +12,7 @@
 						<a href="https://twitter.com/fossjobs_net">Twitter</a> &bull;
 						<a href="ircs://irc.libera.chat/#fossjobs">IRC</a> &bull;
 						<a href="https://www.fossjobs.net/rss/">RSS Feeds</a> &bull;
-						<a href="https://github.com/fossjobs/">Github</a>
+						<a href="https://github.com/fossjobs/">GitHub</a>
 					</p>
 					<hr/>
 				</div>


### PR DESCRIPTION
- Remove dead link to Facebook page/profile
- Mention the various ways to consume the job postings submitted to the platform
- Add IRC and GitHub issues ways to connect with the community

----

Also fix capitalization of "GitHub" in the home page social links.

Before: 
![image](https://github.com/fossjobs/fossjobs/assets/478237/e2f0b381-ed36-4b2a-bee2-cbd95e355aa0)

After:
![image](https://github.com/fossjobs/fossjobs/assets/478237/5c6c4b70-a45b-46d7-b123-a0b59494dd8d)

Note that the capitalization is already correct in the footer links:
![image](https://github.com/fossjobs/fossjobs/assets/478237/c19065f7-c0b1-4d80-85c5-3ff08189ce19)
