### PR TITLE
Add HTML titles for the category pages

### DIFF
--- a/public/page_category.php
+++ b/public/page_category.php
@@ -1,14 +1,17 @@
 <?php
 	$category_var_name = $id;
 	$category = get_category_by_var_name($category_var_name);
-	
+
 	$category_id = $category['id'];
-	
+
+	$title_suffix = $translations['header']['title_sep'] . $translations['header']['name'];
+	$html_title = $translations['category']['jobs_for'] . ' ' . $category['name'] . $title_suffix;
+
 	$type_var_name = $extra;
 	$type_id = get_type_id_by_varname($type_var_name);
-	
+
 	$jobsCount = 0;
-	
+
 	if ($type_id)
 	{
 		$jobsCount =  $job->CountJobs($id, $type_id);
@@ -17,23 +20,23 @@
 	{
 		$jobsCount =  $job->CountJobs($id);
 	}
-	
+
 	$paginatorLink = BASE_URL . URL_JOBS . "/$category_var_name";
 
 	if (isset($type_var_name))
 		$paginatorLink .= "/$type_var_name";
-		
+
 	$paginator = new Paginator($jobsCount, JOBS_PER_PAGE, @$_REQUEST['p']);
 	$paginator->setLink($paginatorLink);
 	$paginator->paginate();
-	
+
 	$firstLimit = $paginator->getFirstLimit();
 	$lastLimit = $paginator->getLastLimit();
-	
+
 	$the_jobs = $job->GetPaginatedJobsForCategory($category_id, $firstLimit, JOBS_PER_PAGE, $type_id);
 
 	$smarty->assign("pages", $paginator->pages_link);
-	
+
 	$smarty->assign('jobs', $the_jobs);
 	$smarty->assign('jobs_count', $jobsCount);
 	$smarty->assign('types', get_types());


### PR DESCRIPTION
Currently the category pages (e.g. [jobs/administrators/](https://www.fossjobs.net/jobs/administrators/), [jobs/editors/](https://www.fossjobs.net/jobs/editors/), etc.) are having the title set to an empty string, `<title></title>` because the `header.tpl` relies on `$seo_title` and falls back to `$html_title`.

The latter was not defined for category pages, and the former is being set to the `title` field of the `categories` DB table, which is apparently empty (as suggested by [db/jobberbase.sql](https://github.com/fossjobs/fossjobs/blob/395ff0d8d7dbe562f3e66ec112cae3d67fa26cb5/db/jobberbase.sql#L38-L66).

By defining `$html_title`, the category pages should now have proper titles (shown in browser tab/window titles), instead of defaulting to the page URL.
