### PR TITLE
Add a .mailmap file to normalize git stats and logs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,14 @@
+fossjobs <webmaster@fossjobs.net>
+fossjobs <webmaster@fossjobs.net> <root@fossjobs.net>
+maiki <maiki@interi.org>
+Matthew Leeds <mleeds@redhat.com>
+midzer <midzer@gmail.com>
+Moritz Bartl <moritz@fossjobs.net>
+Moritz Bartl <moritz@fossjobs.net> <moba@users.noreply.github.com>
+Moritz Bartl <moritz@fossjobs.net> <mo@localhost>
+Paul Wise <pabs3@bonedaddy.net>
+Quintin F Smith <smith.quintin@protonmail.com>
+root <root@informatick.net>
+Ryan Schumacher <j.r.schumacher@gmail.com>
+Waldir Pimenta <waldyrious@gmail.com>
+wolke <wolke@informatick.net>


### PR DESCRIPTION
This file was created based on the output of `git shortlog -sne --all`.

For more information on the structure of the file, see <https://git-scm.com/docs/gitmailmap>.
